### PR TITLE
1.1.2 Support generators as listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polyrhythm",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "author": "Dean Radcliffe",
   "repository": "https://github.com/deanius/polyrhythm",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -361,10 +361,11 @@ function toObservable(_results: any) {
       return () => _results.unsubscribe();
     });
 
-  // A Promise is acceptable
-  if (_results.then) return from(_results);
+  // A Promise or generator is acceptable
+  if (_results.then || typeof _results[Symbol.iterator] === 'function')
+    return from(_results);
 
-  // otherwiser we convert it to a single-item Observable
+  // otherwise we convert it to a single-item Observable
   return of(_results);
 }
 

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -537,6 +537,26 @@ describe('Sequences of Methods', () => {
           },
         ]);
       });
+
+      it('listener may be a generator', function() {
+        const seen = eventsMatching(true, this);
+        expect(1).to.eql(1);
+        listen(
+          'seq',
+          function*({ payload: count }) {
+            for (let i = 1; i <= count; i++) {
+              yield i;
+            }
+          },
+          { trigger: { next: 'seq-value' } }
+        );
+        trigger('seq', 2);
+        expect(seen).to.eql([
+          { type: 'seq', payload: 2 },
+          { type: 'seq-value', payload: 1 },
+          { type: 'seq-value', payload: 2 },
+        ]);
+      });
     });
 
     describe('Error Handling', () => {


### PR DESCRIPTION
Polyrhythm has two ways a listener can make side-effects that feed new events into the event bus:

Via explicit function calling of `trigger`:
```
listen('pair', () => {
  trigger('item', 1);
  trigger('item', 2);
});
```
and via config, that maps the Observable's values to the payloads of `trigger`-ed events
```
listen('pair', () => new Observable(o => {
  o.next(1); o.next(2);
}, { trigger: { next: 'item' });
```

In the second case, where the Observable is only a producer of values (not a caller of functions - in other words more like Redux Saga where only objects representing effects can be returned), a generator would suffice, and the syntax here will work as well.

```
listen('pair', function*() { 
   yield 1; yield 2;
}, { trigger: { next: 'item' });
```